### PR TITLE
chore: onboard to wayworks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "extraKnownMarketplaces": {
+    "wayworks": {
+      "source": { "source": "github", "repo": "SilviaAre95/wayworks" }
+    }
+  },
+  "enabledPlugins": {
+    "shared@wayworks": true,
+    "harness@wayworks": true,
+    "security@wayworks": true,
+    "test-builder@wayworks": true,
+    "feature-bank@wayworks": true,
+    "frontend-dev@wayworks": true,
+    "design@wayworks": true,
+    "web-tester@wayworks": true,
+    "superpowers@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 
-# Claude.ai specific
-CLAUDE.md
 # Personal task tracking
 tasks/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Personal Website (silviadata.dev)
+
+Silvia's personal site/portfolio — ventures, open-source work, consultancy, blog.
+
+## Wayworks config
+- **Stack**: Vite + React (JS, `jsconfig.json`), Tailwind + radix/shadcn-style components (`components.json`), framer-motion + Lenis for motion/scroll
+- **Vault note**: `02-Projects/personal-website.md`
+- **Linear project**: Personal Website
+- **Verify**: `npm run lint && npm run build`
+- **Deploy**: `npm run deploy` → gh-pages → GitHub Pages, CNAME **www.silviadata.dev**
+- **MCPs used**: none
+
+## Constraints
+- The live domain is **silviadata.dev** — the repo name (`silviaarellanor-de`) is historical; `silviaarellanor.de` does not resolve. Never link or configure the old domain.
+- Contact form uses EmailJS with env keys — keys stay in `.env` (see `.env.example`), never committed.
+- This is a public personal site: no client names or private project details beyond what Silvia has already published.


### PR DESCRIPTION
Onboards the site repo to [wayworks](https://github.com/SilviaAre95/wayworks):

- `.claude/settings.json`: plugin fleet — core 5 + `frontend-dev`/`design`/`web-tester` (Vite+React+Tailwind site) + superpowers
- `CLAUDE.md`: Wayworks config header (stack, vault note, Linear project, verify/deploy) + constraints — notably that the live domain is **silviadata.dev**, not the repo-name domain
- **Removes the `.gitignore` rule for CLAUDE.md** — it dated from treating CLAUDE.md as personal scratch; under wayworks it's committed, shared config. Veto by reverting that hunk if you disagree.

Created from origin/main on a chore branch — the in-flight `refactor/obex-light-palette` branch is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)