### PR TITLE
fix: copy + consistency fixes (XARI-77)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Silvia Arellano</title>
+  <title>Silvia Arellano — Data Platform Architect</title>
 </head>
 
 <body>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -63,7 +63,7 @@ export default function Footer() {
 
           {/* Tech Stack or Role */}
           <div className="text-main-mediumGrey text-sm">
-            Senior Data Engineer
+            Data Platform Architect
           </div>
         </div>
       </div>

--- a/src/pages/Header/Header.jsx
+++ b/src/pages/Header/Header.jsx
@@ -74,8 +74,9 @@ export default function Header() {
           <nav className="bg-main-white/90 backdrop-blur-md md:rounded-full px-4 md:px-6 py-2.5 md:shadow-lg">
             {/* Mobile Menu Button */}
             <div className="flex justify-between items-center md:hidden px-2">
-              <a 
-                href="#hero" 
+              <a
+                href="#hero"
+                aria-label="Back to top"
                 onClick={(e) => {
                   e.preventDefault();
                   scrollToSection('hero');

--- a/src/pages/Projects/Projects.jsx
+++ b/src/pages/Projects/Projects.jsx
@@ -30,9 +30,9 @@ const allProjects = [
     year: "2023"
   },
   {
-    title: "End-to-end Data Product: Assitance control dashboard",
+    title: "End-to-end Data Product: Attendance control dashboard",
     description:
-      "Built a reusable Power BI data product with BigQuery ELT pipelines and optimized modelling, enabling insights on workers assitance management. This product was sold by the company to a large national client.",
+      "Built a reusable Power BI data product with BigQuery ELT pipelines and optimized modelling, enabling insights on worker attendance management. This product was sold by the company to a large national client.",
     backgroundImage: demoImage,
     githubLink: null,
     liveLink: null,


### PR DESCRIPTION
Closes the three findings from the 2026-07-10 design review:

1. **Typo**: "Assitance control dashboard" → "**Attendance** control dashboard" (the product is an employee-attendance dashboard; card description fixed too)
2. **One title everywhere**: footer said "Senior Data Engineer" while the hero says "Data Platform Architect" — footer aligned; `<title>` now "Silvia Arellano — Data Platform Architect" (the hero typewriter cycling 4 specialties is by design and untouched)
3. **A11y**: the mobile brand link visually shows the active section (a feature) but its accessible name duplicated "Contact" while linking to `#hero` — now `aria-label="Back to top"`

Verified: build green; the 22 lint errors in touched files are pre-existing `react/prop-types` debt (repo-wide: 130 — worth its own issue).

Linear: XARI-77

🤖 Generated with [Claude Code](https://claude.com/claude-code)