### PR TITLE
feat: deploy to GitHub Pages on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,22 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What

**Finding**: the live site was **11 months stale** — `gh-pages` branch last pushed Aug 2025; every merge since (blogs, XARI-77 fixes, lint work) never reached silviadata.dev, because deploys were manual (`npm run deploy` from a laptop).

**Change**: merge → live, automatically.
- Pages `build_type` switched `legacy` → `workflow` (custom domain `www.silviadata.dev` is a Pages setting and is preserved)
- `verify` job uploads `dist/` as a Pages artifact on main pushes; new `deploy` job publishes it (`actions/deploy-pages`, OIDC, minimal permissions)
- PRs still get lint+build only — no deploy

**Merging this PR is itself the first automated deploy** — it will finally ship ~a year of accumulated main to the live site. Give it a look at silviadata.dev afterwards (the `<title>` should change as the visible marker).

`npm run deploy` and the `gh-pages` branch are now unused; the branch can be deleted after the first successful deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)