### PR TITLE
fix: mobile horizontal overflow in hero typewriter (XARI-76)

### DIFF
--- a/src/pages/Hero/Hero.jsx
+++ b/src/pages/Hero/Hero.jsx
@@ -13,7 +13,7 @@ export default function Hero() {
   return (
     <section
       id="hero"
-      className="hero-section relative min-h-screen bg-main-white py-16 sm:py-20 md:py-32 flex items-center"
+      className="hero-section relative min-h-screen bg-main-white py-16 sm:py-20 md:py-32 flex items-center overflow-x-clip"
     >
       {/* Simple background gradient */}
       <div className="absolute inset-0 bg-gradient-to-br from-main-lightGrey via-main-white to-main-lightGrey pointer-events-none"></div>
@@ -38,11 +38,12 @@ export default function Hero() {
                 </h1>
               </div>
 
-              {/* Role badge */}
-              <div className="inline-flex items-center gap-3 px-6 py-3 rounded-xl bg-main-lightGrey border border-main-mediumGrey/30 mb-8">
-                <span>
+              {/* Role badge — max-w-full + responsive text so long titles wrap instead of
+                  overflowing the viewport on small screens (XARI-76) */}
+              <div className="inline-flex items-center gap-3 px-4 sm:px-6 py-3 rounded-xl bg-main-lightGrey border border-main-mediumGrey/30 mb-8 max-w-full">
+                <span className="min-w-0">
                   <FlipWords
-                    className="text-xl text-accent-softBlue font-medium"
+                    className="text-lg sm:text-xl text-accent-softBlue font-medium"
                     words={words}
                   />
                 </span>


### PR DESCRIPTION
## Root cause

The role-badge pill grows with its content (`inline-flex` + `px-6`), and the FlipWords typewriter's longest titles at `text-xl` exceed narrow viewports — nothing clipped them, so the entire page gained horizontal scroll. Intermittent by nature: depends on which word is showing (why the original measurement said 413px and later ones varied).

## Fix

- Badge: `max-w-full` (long titles now wrap within the pill), `px-4 sm:px-6`, `text-lg sm:text-xl`
- Hero section: `overflow-x-clip` — guards the exit animation, which translates words `x:40` while absolute-positioned

## Verification

Built + served `dist/` locally; measured `scrollWidth` continuously through 3 full typewriter cycles at **320 / 360 / 390px** — max equals viewport width at all three (was 396/412/398). CI runs lint+build on this PR; merging auto-deploys.

Linear: XARI-76

🤖 Generated with [Claude Code](https://claude.com/claude-code)