### PR TITLE
feat: consulting-first positioning (XARI-78)

### DIFF
--- a/src/pages/Contact/Contact.jsx
+++ b/src/pages/Contact/Contact.jsx
@@ -102,11 +102,17 @@ export default function Contact() {
             <div className="space-y-8">
               <div>
                 <h2 className="text-4xl font-bold mb-4 text-main-darkGrey">
-                  Get in Touch
+                  Work with me
                 </h2>
                 <p className="text-main-mediumGrey text-lg">
-                  Working on a project or just curious about all things data?
-                  Drop me a message!
+                  I take on consulting engagements in data platform architecture,
+                  GCP/BigQuery, and AI-assisted delivery — from audits and pipeline
+                  rescues to building your data platform end to end. For larger
+                  engagements I work with a small, trusted team of specialists.
+                </p>
+                <p className="text-main-mediumGrey text-lg mt-3">
+                  Tell me what you&apos;re building and I&apos;ll get back to you
+                  within a couple of days.
                 </p>
               </div>
 

--- a/src/pages/Hero/Hero.jsx
+++ b/src/pages/Hero/Hero.jsx
@@ -52,32 +52,42 @@ export default function Hero() {
               {/* Description */}
               <div className="mb-12 max-w-xl">
                 <p className="text-lg text-main-darkGrey/80 leading-relaxed">
-                  Architecting robust data solutions and transforming complex datasets 
-                  into actionable insights. Specialized in building scalable ETL pipelines 
-                  and data infrastructure.
+                  Architecting robust data solutions and transforming complex datasets
+                  into actionable insights. Specialized in scalable ETL pipelines and
+                  data infrastructure — and building open-source tools for AI-assisted
+                  development.
                 </p>
               </div>
 
-              {/* CTA Buttons */}
+              {/* CTA Buttons — consulting-primary (XARI-78) */}
               <div className="flex flex-col sm:flex-row gap-4">
-                {/* View Projects Button */}
+                {/* Work with me (primary) */}
                 <a
-                  href="#projects"
+                  href="#contact"
                   className="inline-flex items-center justify-center px-8 py-4 rounded-lg bg-accent-softBlue hover:bg-accent-mutedTeal text-white font-medium transition-colors duration-200"
                 >
-                  <span>View Projects</span>
+                  <span>Work with me</span>
                   <i className="fas fa-arrow-right ml-2"></i>
                 </a>
 
-                {/* Resume Button */}
+                {/* View Projects (secondary) */}
+                <a
+                  href="#projects"
+                  className="inline-flex items-center justify-center px-8 py-4 rounded-lg bg-main-white hover:bg-main-lightGrey text-main-darkGrey font-medium border border-main-mediumGrey/30 transition-colors duration-200"
+                >
+                  <span>View Projects</span>
+                </a>
+              </div>
+
+              {/* Resume: available, deliberately not a primary CTA */}
+              <div className="mt-4">
                 <a
                   href="https://drive.google.com/file/d/1JeufhD5nm2EDt2PVQKtxptWcRrz6ITY1/view?usp=sharing"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center px-8 py-4 rounded-lg bg-main-white hover:bg-main-lightGrey text-main-darkGrey font-medium border border-main-mediumGrey/30 transition-colors duration-200"
+                  className="text-sm text-main-mediumGrey hover:text-accent-softBlue underline underline-offset-4 transition-colors duration-200"
                 >
-                  <span>Get Resume</span>
-                  <i className="fas fa-download ml-2"></i>
+                  Looking to hire full-time? Get my resume
                 </a>
               </div>
             </div>

--- a/src/pages/Skills/Skills.jsx
+++ b/src/pages/Skills/Skills.jsx
@@ -198,6 +198,33 @@ const SkillsSection = () => {
     },
     {
       icon: Paintbrush,
+      title: "AI & Agents",
+      color: "text-purple-400",
+      skills: [
+        {
+          name: "Claude Code",
+          icon: <Cpu className="w-4 h-4 text-[#D97706]" />,
+        },
+        {
+          name: "Agent Workflows & MCP",
+          icon: <Cpu className="w-4 h-4 text-[#7C3AED]" />,
+        },
+        {
+          name: "AI-Assisted Delivery (wayworks)",
+          icon: <FaCode className="w-4 h-4 text-[#0EA5E9]" />,
+        },
+        {
+          name: "Local LLMs (Ollama)",
+          icon: <Cpu className="w-4 h-4 text-[#059669]" />,
+        },
+        {
+          name: "LLM Data Pipelines",
+          icon: <Cpu className="w-4 h-4 text-[#DC2626]" />,
+        },
+      ],
+    },
+    {
+      icon: Cpu,
       title: "Professional Skills",
       color: "text-yellow-400",
       skills: [


### PR DESCRIPTION
Implements the reframed XARI-78 — the site's conversion goal is consulting engagements, personally framed (ObexData stays the corporate vehicle):

- **Hero**: primary CTA is now **Work with me** → contact; View Projects secondary; resume demoted to a small text link explicitly labeled for full-time recruiters (dual-audience preserved, hierarchy decided)
- **Hero subline**: adds "…and building open-source tools for AI-assisted development"
- **Contact → "Work with me"**: engagement scope (data platform architecture, GCP/BigQuery, AI-assisted delivery), the *small trusted team* capacity line, response expectation
- **Skills**: new **AI & Agents** category — Claude Code, agent workflows & MCP, AI-assisted delivery (wayworks), local LLMs, LLM data pipelines

Verified headlessly: 7/7 assertions incl. CTA scroll-to-contact. Copy is my draft of your positioning — edit voice freely.

Linear: XARI-78

🤖 Generated with [Claude Code](https://claude.com/claude-code)