### PR TITLE
fix: remove public resume link from hero

### DIFF
--- a/src/pages/Hero/Hero.jsx
+++ b/src/pages/Hero/Hero.jsx
@@ -78,18 +78,6 @@ export default function Hero() {
                   <span>View Projects</span>
                 </a>
               </div>
-
-              {/* Resume: available, deliberately not a primary CTA */}
-              <div className="mt-4">
-                <a
-                  href="https://drive.google.com/file/d/1JeufhD5nm2EDt2PVQKtxptWcRrz6ITY1/view?usp=sharing"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-main-mediumGrey hover:text-accent-softBlue underline underline-offset-4 transition-colors duration-200"
-                >
-                  Looking to hire full-time? Get my resume
-                </a>
-              </div>
             </div>
 
             {/* Right column - Photo */}


### PR DESCRIPTION
Removes the "Looking to hire full-time? Get my resume" text link — a public job-seeking signal is a risk with a current employer, and consulting buyers don't need it. The resume stays shareable privately (the Drive link still exists, just not published on the site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)