### PR TITLE
refactor: OBEX light palette — project cards with outcome metrics, About page restored

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist",
+    "postbuild": "cp dist/index.html dist/404.html"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
+import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import "./assets/css/index.css";
-import Experience from "./pages/Experience/Experience";
+import About from "./pages/About/About";
 import Contact from "./pages/Contact/Contact";
 import Projects from "./pages/Projects/Projects";
 import Header from "./pages/Header/Header";
@@ -17,12 +18,25 @@ export default function App() {
   const location = useLocation();
   const isProductsPage = location.pathname === '/products';
 
+  useEffect(() => {
+    const hash = location.hash.slice(1);
+    if (hash && location.pathname === '/') {
+      const timer = setTimeout(() => {
+        const el = document.getElementById(hash);
+        if (el) {
+          const top = el.getBoundingClientRect().top + window.pageYOffset - 80;
+          window.scrollTo({ top, behavior: 'smooth' });
+        }
+      }, 150);
+      return () => clearTimeout(timer);
+    }
+  }, [location]);
+
   // Home page component that contains all sections
   const HomePage = () => (
     <>
       <Hero />
       <Skills />
-      <Experience />
       <Projects />
       <IndustryBanner />
       <Blog />
@@ -36,6 +50,7 @@ export default function App() {
       <main className="flex-grow pb-20">
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/about" element={<About />} />
           <Route path="/products" element={<Products />} />
         </Routes>
       </main>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Hero from "./pages/Hero/Hero";
 import Skills from "./pages/Skills/Skills";
 import Blog from "./pages/Blog/Blog";
 import Products from "./pages/Products/Products";
+import Legal from "./pages/Legal/Legal";
 import IndustryBanner from "./components/IndustryBanner";
 import Footer from "./components/Footer";
 
@@ -52,6 +53,7 @@ export default function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="/about" element={<About />} />
           <Route path="/products" element={<Products />} />
+          <Route path="/legal" element={<Legal />} />
         </Routes>
       </main>
       {!isProductsPage && <Footer />}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -10,7 +10,7 @@ export default function Footer() {
         <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
           {/* Copyright */}
           <div className="text-main-mediumGrey text-sm">
-            © {currentYear} Silvia Arellano. All rights reserved.
+            © {currentYear} OBEXDATA OÜ. All rights reserved.
           </div>
 
           {/* Professional Links */}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -10,7 +10,7 @@ export default function Footer() {
         <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
           {/* Copyright */}
           <div className="text-main-mediumGrey text-sm">
-            © {currentYear} OBEXDATA OÜ. All rights reserved.
+            © {currentYear} Silvia Arellano · Consulting via OBEXDATA OÜ
           </div>
 
           {/* Professional Links */}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -10,7 +10,10 @@ export default function Footer() {
         <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
           {/* Copyright */}
           <div className="text-main-mediumGrey text-sm">
-            © {currentYear} Silvia Arellano · Consulting via OBEXDATA OÜ
+            © {currentYear} Silvia Arellano · Consulting via OBEXDATA OÜ ·{" "}
+            <a href="/legal" className="hover:text-accent-softBlue underline underline-offset-2">
+              Legal &amp; privacy
+            </a>
           </div>
 
           {/* Professional Links */}

--- a/src/pages/Header/Header.jsx
+++ b/src/pages/Header/Header.jsx
@@ -23,7 +23,6 @@ export default function Header() {
   const navLinks = [
     { id: "hero", icon: FaHome, text: "Home" },
     { id: "skills", icon: FaCode, text: "Skills" },
-    { id: "experience", icon: FaBriefcase, text: "Experience" },
     { id: "projects", icon: FaLaptopCode, text: "Projects" },
     { id: "blog", icon: FaBlog, text: "Blog" },
     { id: "contact", icon: FaEnvelope, text: "Contact" },
@@ -97,7 +96,11 @@ export default function Header() {
                     href={`#${id}`}
                     onClick={(e) => {
                       e.preventDefault();
-                      scrollToSection(id);
+                      if (location.pathname !== '/') {
+                        navigate(`/#${id}`);
+                      } else {
+                        scrollToSection(id);
+                      }
                       setIsMenuOpen(false);
                     }}
                     className={`px-3 py-2 md:py-1.5 rounded-lg md:rounded-full text-sm font-medium
@@ -118,6 +121,28 @@ export default function Header() {
                     <span className="inline">{text}</span>
                   </a>
                 ))}
+                {/* About page link */}
+                <a
+                  href="/about"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    navigate('/about');
+                    setIsMenuOpen(false);
+                  }}
+                  className={`px-3 py-2 md:py-1.5 rounded-lg md:rounded-full text-sm font-medium
+                    transition-all duration-300 flex items-center gap-2
+                    hover:bg-main-mediumGrey/10 cursor-pointer
+                    ${
+                      location.pathname === '/about'
+                        ? "bg-accent-softBlue/20 text-accent-softBlue"
+                        : "text-main-mediumGrey hover:text-main-darkGrey"
+                    }
+                  `}
+                >
+                  <FaUser className={`text-base ${location.pathname === '/about' ? "scale-110" : ""}`} />
+                  <span className="inline">About</span>
+                </a>
+
                 {/* Products Link - Temporarily hidden until Gumroad page is ready */}
                 {/* <a
                   href="/products"

--- a/src/pages/Header/Header.jsx
+++ b/src/pages/Header/Header.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import {
   FaHome,
   FaLaptopCode,
-  FaBriefcase,
+  FaUser,
   FaCode,
   FaEnvelope,
   FaBars,
@@ -13,6 +14,8 @@ export default function Header() {
   const [activeLink, setActiveLink] = useState("hero");
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [, setWindowWidth] = useState(window.innerWidth);
+  const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     const handleResize = () => setWindowWidth(window.innerWidth);

--- a/src/pages/Legal/Legal.jsx
+++ b/src/pages/Legal/Legal.jsx
@@ -1,0 +1,79 @@
+export default function Legal() {
+  return (
+    <section className="min-h-screen bg-main-white py-24">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 space-y-12">
+        <div>
+          <h1 className="text-4xl font-bold text-main-darkGrey mb-2">Legal &amp; Privacy</h1>
+          <p className="text-main-mediumGrey">
+            Information about the entity behind this site and how your data is handled.
+          </p>
+        </div>
+
+        {/* Imprint / provider identification (EU eCommerce Directive Art. 5) */}
+        <div>
+          <h2 className="text-2xl font-semibold text-main-darkGrey mb-4">Provider identification</h2>
+          <div className="text-main-mediumGrey space-y-1">
+            <p>This is the personal site of Silvia Arellano.</p>
+            <p>Consulting engagements offered through this site are contracted by:</p>
+            <div className="mt-3 pl-4 border-l-2 border-main-mediumGrey/30 space-y-1">
+              <p className="text-main-darkGrey font-medium">OBEXDATA OÜ</p>
+              <p>Registry code: [REGISTRY_CODE]</p>
+              <p>Registered address: [REGISTERED_ADDRESS]</p>
+              <p>
+                Email:{" "}
+                <a href="mailto:[LEGAL_EMAIL]" className="text-accent-softBlue hover:text-accent-mutedTeal">
+                  [LEGAL_EMAIL]
+                </a>
+              </p>
+              {/* Uncomment if VAT-registered:
+              <p>VAT number: [VAT_NUMBER]</p> */}
+            </div>
+          </div>
+        </div>
+
+        {/* Privacy notice (GDPR) */}
+        <div>
+          <h2 className="text-2xl font-semibold text-main-darkGrey mb-4">Privacy notice</h2>
+          <div className="text-main-mediumGrey space-y-4">
+            <p>
+              <span className="text-main-darkGrey font-medium">Contact form.</span>{" "}
+              When you use the contact form, the details you submit (name, email address,
+              subject, message) are transmitted via EmailJS (EmailJS Inc., USA) and delivered
+              to us by email. We use them solely to respond to your inquiry and to follow up
+              on potential engagements — never for marketing lists, and they are not sold or
+              shared beyond that purpose. Messages are kept only as long as needed to handle
+              the conversation; you can request deletion at any time via the email above.
+            </p>
+            <p>
+              <span className="text-main-darkGrey font-medium">No tracking.</span>{" "}
+              This site sets no cookies and runs no analytics or advertising trackers.
+            </p>
+            <p>
+              <span className="text-main-darkGrey font-medium">Hosting.</span>{" "}
+              The site is served by GitHub Pages (GitHub, Inc., USA), which may log technical
+              request data (such as IP addresses) for security and operations per{" "}
+              <a
+                href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent-softBlue hover:text-accent-mutedTeal"
+              >
+                GitHub&apos;s privacy statement
+              </a>.
+            </p>
+            <p>
+              <span className="text-main-darkGrey font-medium">Your rights.</span>{" "}
+              Under the GDPR you may request access, correction, or deletion of your personal
+              data, and you may lodge a complaint with a supervisory authority. Contact us at
+              the email above for any of these.
+            </p>
+          </div>
+        </div>
+
+        <a href="/" className="inline-block text-accent-softBlue hover:text-accent-mutedTeal">
+          ← Back to the site
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Legal/Legal.jsx
+++ b/src/pages/Legal/Legal.jsx
@@ -17,16 +17,14 @@ export default function Legal() {
             <p>Consulting engagements offered through this site are contracted by:</p>
             <div className="mt-3 pl-4 border-l-2 border-main-mediumGrey/30 space-y-1">
               <p className="text-main-darkGrey font-medium">OBEXDATA OÜ</p>
-              <p>Registry code: [REGISTRY_CODE]</p>
-              <p>Registered address: [REGISTERED_ADDRESS]</p>
+              <p>Registry code: 16916965</p>
+              <p>Registered address: Lätte, Tsirgu küla, Setomaa vald, Võru maakond 65346, Estonia</p>
               <p>
                 Email:{" "}
-                <a href="mailto:[LEGAL_EMAIL]" className="text-accent-softBlue hover:text-accent-mutedTeal">
-                  [LEGAL_EMAIL]
+                <a href="mailto:info@obexdata.io" className="text-accent-softBlue hover:text-accent-mutedTeal">
+                  info@obexdata.io
                 </a>
               </p>
-              {/* Uncomment if VAT-registered:
-              <p>VAT number: [VAT_NUMBER]</p> */}
             </div>
           </div>
         </div>

--- a/src/pages/Projects/Projects.jsx
+++ b/src/pages/Projects/Projects.jsx
@@ -12,6 +12,10 @@ const allProjects = [
     title: "wayworks — an open-source way of work",
     description:
       "Claude Code plugin marketplace for AI-assisted building: 15 plugins with workflow loops, feature-spec governance, and browser testing — linked to a second brain (Obsidian) and a tracker (Linear). Install: claude plugin marketplace add SilviaAre95/wayworks",
+    outcomes: [
+      { value: "15", label: "plugins" },
+      { value: "43", label: "skills" },
+    ],
     backgroundImage: wayworksImage,
     githubLink: "https://github.com/SilviaAre95/wayworks",
     liveLink: null,
@@ -19,9 +23,13 @@ const allProjects = [
     year: "2026"
   },
   {
-    title: "Enterprise-Level MongoDB CDC Data Service",
+    title: "Near-Real-Time MongoDB CDC Pipeline",
     description:
-      "Built a scalable CDC pipeline from MongoDB to BigQuery using Pub/Sub and Dataflow, with dynamic table routing and resume token handling. Automated collection detection and supported schema evolution for continuous integration.",
+      "Replaced SQL-based ingestion with a private Python library using storage_write_api and CDC — cutting resource waste by ~80%. Redesigned the streaming architecture on Pub/Sub + Dataflow with dynamic table routing and schema evolution, achieving a 76% cost reduction.",
+    outcomes: [
+      { value: "76%", label: "cost reduction" },
+      { value: "~80%", label: "less resource waste" },
+    ],
     backgroundImage: mongoImage,
     githubLink: null,
     liveLink: null,
@@ -31,17 +39,24 @@ const allProjects = [
   {
     title: "Real Estate Data Analytics Platform",
     description:
-      "Developed a GCP-based data product with BigQuery and Looker Studio, automating operations and centralizing construction and sales monitoring.",
+      "GCP data product centralising construction and sales monitoring for a major property developer. Automated the full operational lifecycle — from build status to sales pipeline — into a single BigQuery + Looker Studio platform.",
+    outcomes: [
+      { value: "1", label: "unified platform" },
+      { value: "100%", label: "ops automated" },
+    ],
     backgroundImage: homaImage,
     githubLink: null,
     liveLink: null,
-    company: "Grupo Homa - Real Estate Developers",
+    company: "Grupo Homa",
     year: "2023"
   },
   {
-    title: "End-to-end Data Product: Attendance control dashboard",
+    title: "Attendance Control Data Product",
     description:
-      "Built a reusable Power BI data product with BigQuery ELT pipelines and optimized modelling, enabling insights on worker attendance management. This product was sold by the company to a large national client.",
+      "Reusable Power BI data product backed by optimised BigQuery ELT pipelines. Built to be white-labelled — the company sold it to a large national enterprise client as their own product.",
+    outcomes: [
+      { value: "Enterprise", label: "client deal closed" },
+    ],
     backgroundImage: demoImage,
     githubLink: null,
     liveLink: null,
@@ -51,7 +66,8 @@ const allProjects = [
   {
     title: "Data Engineer Portfolio",
     description:
-      "The complete code of how I built my portfolio using and contributing to open source.",
+      "The complete code of how I built this site — open source and built with React, Vite, and Tailwind.",
+    outcomes: [],
     backgroundImage: profileImage,
     githubLink: "https://github.com/SilviaAre95/silviaarellanor-de",
     liveLink: null,
@@ -85,6 +101,23 @@ const ProjectCard = ({ project }) => (
       <h3 className="text-lg font-semibold text-main-darkGrey mb-2 line-clamp-2">
         {project.title}
       </h3>
+
+      {/* Outcome metrics */}
+      {project.outcomes?.length > 0 && (
+        <div className="flex gap-4 mb-3 pb-3 border-b border-main-mediumGrey/20">
+          {project.outcomes.map((outcome, i) => (
+            <div key={i}>
+              <div className="text-accent-softBlue font-bold text-base leading-tight">
+                {outcome.value}
+              </div>
+              <div className="text-main-mediumGrey text-xs leading-tight">
+                {outcome.label}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
       <p className="text-main-mediumGrey mb-4 line-clamp-3 text-sm">
         {project.description}
       </p>


### PR DESCRIPTION
The long-running palette branch, rebased onto main (absorbing PRs #12–#20) and repaired:

## Yours (the WIP)
- Project cards rewritten with **outcome metrics** (76% cost reduction, enterprise deal closed, …) and sharper titles
- About page + nav link restored; Footer/App/Header updates

## Merge resolution notes
- Kept your card structure and titles; grafted in the **wayworks card** (now with 15-plugins/43-skills metrics in your outcome format) and the **"Ask me about this →" CTAs**
- Repaired a silent auto-merge landmine: your About link uses `navigate`/`location`/`FaUser`, whose imports main's lint sweep had removed — git merged both sides into a runtime blank page. Imports restored.
- Footer: **© Silvia Arellano · Consulting via OBEXDATA OÜ** — personal brand first, contracting entity named (per today's positioning decision)

## Verification
Build + lint green; full headless render check 8/8 — your titles, outcome metrics, wayworks card, CTAs, consulting copy, OBEX footer all present. The resume link visible on this branch is inherited from pre-#21 main and disappears when **PR #21 merges — merge #21 first**, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)