### PR TITLE
chore: add VAT number to imprint (missed PR #22's merge window)

### DIFF
--- a/src/pages/Legal/Legal.jsx
+++ b/src/pages/Legal/Legal.jsx
@@ -19,6 +19,7 @@ export default function Legal() {
               <p className="text-main-darkGrey font-medium">OBEXDATA OÜ</p>
               <p>Registry code: 16916965</p>
               <p>Registered address: Lätte, Tsirgu küla, Setomaa vald, Võru maakond 65346, Estonia</p>
+              <p>VAT number: EE102706675</p>
               <p>
                 Email:{" "}
                 <a href="mailto:info@obexdata.io" className="text-accent-softBlue hover:text-accent-mutedTeal">


### PR DESCRIPTION
One commit that landed on the palette branch right after PR #22 was merged: adds `VAT number: EE102706675` to the OBEXDATA OÜ imprint block on /legal. Nothing else — `git log main..branch` shows exactly this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)