### PR TITLE
fix(resume): lead each Playtomic role with its most recent work

### DIFF
--- a/resume/content/senior-current-resume.tex
+++ b/resume/content/senior-current-resume.tex
@@ -27,12 +27,12 @@ I'm a data engineer. I build data infrastructure on GCP, from the ingestion pipe
 \newcommand{\SeniorCurrentExperience}{%
 \ResumeRole{Lead Data Engineer}{Playtomic}{Oct 2025}{Present}%
 \begin{ResumeBullets}
+  \ResumeBullet{Deployed Cube Core on Kubernetes for the semantic layer, then built an MCP server over it so people could query company data through Claude, ChatGPT, and Cursor, with a business glossary keeping terms consistent.}%
+  \ResumeBullet{Built the framework other engineering teams use to ship pipelines to our standards, with governance, alerting, and cost controls built in.}%
   \ResumeBullet{Reduced pipeline development time from weeks to a few days through an internal Beam framework and templated CI/CD.}%
   \ResumeBullet{Cut streaming pipeline costs by up to 60\% with a GCP cost and monitoring framework now used platform-wide.}%
   \ResumeBullet{Brought streaming latency under one second, which opened up use cases the previous architecture couldn't handle.}%
   \ResumeBullet{Built an agent framework that puts AI assistance into pipeline development, ops, and quality work.}%
-  \ResumeBullet{Deployed Cube Core on Kubernetes for the semantic layer, then built an MCP server over it so people could query company data through Claude, ChatGPT, and Cursor, with a business glossary keeping terms consistent.}%
-  \ResumeBullet{Built the framework other engineering teams use to ship pipelines to our standards, with governance, alerting, and cost controls built in.}%
 \end{ResumeBullets}%
 \ResumeRole{Global Senior Data Engineer}{Playtomic}{Apr 2024}{Oct 2025}%
 \begin{ResumeBullets}

--- a/resume/variants/data-leadership.tex
+++ b/resume/variants/data-leadership.tex
@@ -24,9 +24,9 @@ Data engineering leader and architect with 6+ years of experience building platf
 \PlaytomicLeadRole
 \begin{ResumeBullets}
   \PlaytomicLeadership
-  \PlaytomicSelfServeFrameworkLead
   \PlaytomicMcpSemanticLayerLead
   \PlaytomicMcpAdoption
+  \PlaytomicSelfServeFrameworkLead
   \PlaytomicStreamingImpact
   \PlaytomicAdkAgents
 \end{ResumeBullets}

--- a/resume/variants/forward-deployed-engineer.tex
+++ b/resume/variants/forward-deployed-engineer.tex
@@ -29,8 +29,8 @@ Data and AI engineer with 6+ years of experience, working both as a consultant a
 
 \PlaytomicLeadRole
 \begin{ResumeBullets}
-  \PlaytomicBeamFramework
   \PlaytomicSelfServeFramework
+  \PlaytomicBeamFramework
   \PlaytomicLatencyAndLiveProducts
   \PlaytomicObservability
 \end{ResumeBullets}


### PR DESCRIPTION
Within the Lead Data Engineer role the bullets ran oldest first, so the semantic layer and the self-service pipeline framework sat at the bottom. Both are the most recent work and the most differentiating, so they now open the role.

- **Senior**: Cube Core on Kubernetes + the MCP server, then the self-service framework, then the older Beam framework, cost, and latency wins.
- **FDE**: self-service framework ahead of the Beam framework.
- **Leadership**: semantic layer and its adoption, then the framework.

Ordering only. No wording, facts, or numbers changed.

## Note on how this got here

PR #32 was merged while this commit was being pushed to the same branch, so it landed on an already-merged branch with no open PR. Cherry-picked onto a fresh branch off `main` rather than reopening #32.

## Verification

96/96 tests, pinned Tectonic build, publication verifier. All three PDFs still exactly two pages with five correct links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)